### PR TITLE
build(foreach): handle arguments robustly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -118,8 +118,8 @@ build_6x_7x_old () {
 
 foreach () {
   declare -r command="${1}";
-  declare -r args="${@:2}";
-  for _arg in ${args}; do
+  declare -r args=("${@:2}");
+  for _arg in "${args[@]}"; do
     "${command}" "${_arg}";
   done;
 };


### PR DESCRIPTION
Fix some shellcheck warnings and, more importantly, handle the arguments more robustly by not word-splitting arguments. An invocation like

    foreach F "a b" c

would have run `F a; F b; F c`. Make it run `F "a b"; F c` as expected.